### PR TITLE
Add CsvResultsWriterFactory

### DIFF
--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/writer/CsvResultsWriterFactory.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/writer/CsvResultsWriterFactory.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jmh.mbr.core.writer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.format.OutputFormat;
+import org.openjdk.jmh.util.FileUtils;
+import org.openjdk.jmh.util.ScoreFormatter;
+import org.openjdk.jmh.util.Statistics;
+
+import jmh.mbr.core.ResultsWriter;
+import jmh.mbr.core.ResultsWriterFactory;
+
+/**
+ * A {@link ResultsWriterFactory} that writes the output in csv format (to the console and to a file). Activated with
+ * <code>-DpublishTo=csv:./path/to/file.csv</code>. The file will be overwritten if it already exists. If the file
+ * cannot be written a warning will be printed on the console.
+ * 
+ * @author Dave Syer
+ */
+public class CsvResultsWriterFactory implements ResultsWriterFactory {
+
+	@Override
+	public ResultsWriter forUri(String uri) {
+
+		if (!uri.startsWith("csv:")) {
+			return null;
+		}
+
+		return new ResultsWriter() {
+
+			@Override
+			public void write(OutputFormat output, Collection<RunResult> results) {
+
+				StringBuilder report = new StringBuilder(System.lineSeparator());
+
+				try {
+					Map<String, Integer> params = new LinkedHashMap<>();
+					int paramPlaces = 0;
+					for (RunResult result : results) {
+						if (result.getParams() != null) {
+							for (String param : result.getParams().getParamsKeys()) {
+								int count = paramPlaces;
+								if (params.containsKey(param)) {
+									continue;
+								}
+								params.put(param, count);
+								paramPlaces++;
+							}
+						}
+					}
+
+					Map<String, Integer> auxes = new LinkedHashMap<>();
+					int auxPlaces = 0;
+					for (RunResult result : results) {
+						if (result.getAggregatedResult() != null) {
+							@SuppressWarnings("rawtypes")
+							Map<String, Result> second = result.getAggregatedResult().getSecondaryResults();
+							if (second != null) {
+								for (String aux : second.keySet()) {
+									int count = auxPlaces;
+									auxes.computeIfAbsent(aux, key -> count);
+									auxPlaces++;
+								}
+							}
+						}
+					}
+
+					StringBuilder header = new StringBuilder();
+					header.append("class, method, ");
+					params.forEach((key, value) -> header.append(key).append(", "));
+					auxes.forEach((key, value) -> header.append(propertyName(key)).append(", "));
+					header.append("median, mean, range");
+					report.append(header.toString()).append(System.lineSeparator());
+
+					for (RunResult result : results) {
+						StringBuilder builder = new StringBuilder();
+						if (result.getParams() != null) {
+							String benchmark = result.getParams().getBenchmark();
+							String cls = benchmark.contains(".") ? benchmark.substring(0, benchmark.lastIndexOf(".")) : benchmark;
+							String mthd = benchmark.substring(benchmark.lastIndexOf(".") + 1);
+							builder.append(cls).append(", ").append(mthd).append(", ");
+							for (int i = 0; i < params.values().size(); i++) {
+								boolean found = false;
+								for (String param : result.getParams().getParamsKeys()) {
+									if (params.get(param) == i) {
+										builder.append(result.getParams().getParam(param)).append(", ");
+										found = true;
+									}
+								}
+								if (!found) {
+									builder.append(", ");
+								}
+							}
+						}
+
+						if (result.getAggregatedResult() != null) {
+							@SuppressWarnings("rawtypes")
+							Map<String, Result> second = result.getAggregatedResult().getSecondaryResults();
+							for (int i = 0; i < auxes.values().size(); i++) {
+								boolean found = false;
+								for (String param : second.keySet()) {
+									if (auxes.get(param) == i) {
+										builder.append(ScoreFormatter.format(second.get(param).getStatistics().getPercentile(0.5)))
+												.append(", ");
+										found = true;
+									}
+								}
+								if (!found) {
+									builder.append(", ");
+								}
+							}
+							// primary result is derived from aggregate result
+							Statistics statistics = result.getPrimaryResult().getStatistics();
+							builder.append(ScoreFormatter.format(statistics.getPercentile(0.5)));
+							builder.append(", ");
+							builder.append(ScoreFormatter.format(statistics.getMean()));
+							builder.append(", ");
+							double error = (statistics.getMax() - statistics.getMin()) / 2;
+							builder.append(ScoreFormatter.format(error));
+							report.append(builder.toString()).append(System.lineSeparator());
+						}
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+
+				output.println(report.toString());
+
+				File file = new File(uri.substring("csv:".length()));
+				output.println(System.lineSeparator());
+				output.println("Writing result to file: " + file);
+				file.getParentFile().mkdirs();
+				if (file.getParentFile().exists()) {
+					try {
+						FileUtils.writeLines(file, Collections.singleton(report.toString()));
+					} catch (IOException e) {
+						output.println("Failed: " + e.getMessage());
+					}
+				}
+
+			}
+
+			private String propertyName(String key) {
+				if (key.matches("get[A-Z].*")) {
+					key = changeFirstCharacterCase(key.substring(3), false);
+				}
+				return key;
+			}
+		};
+	}
+
+	private static String changeFirstCharacterCase(String str, boolean capitalize) {
+		if (str == null || str.length() == 0) {
+			return str;
+		}
+
+		char baseChar = str.charAt(0);
+		char updatedChar;
+		if (capitalize) {
+			updatedChar = Character.toUpperCase(baseChar);
+		} else {
+			updatedChar = Character.toLowerCase(baseChar);
+		}
+		if (baseChar == updatedChar) {
+			return str;
+		}
+
+		char[] chars = str.toCharArray();
+		chars[0] = updatedChar;
+		return new String(chars, 0, chars.length);
+	}
+
+}

--- a/microbenchmark-runner-core/src/main/resources/META-INF/services/jmh.mbr.core.ResultsWriterFactory
+++ b/microbenchmark-runner-core/src/main/resources/META-INF/services/jmh.mbr.core.ResultsWriterFactory
@@ -1,0 +1,1 @@
+jmh.mbr.core.writer.CsvResultsWriterFactory

--- a/microbenchmark-runner-core/src/test/java/jmh/mbr/core/writer/CsvResultsWriterFactoryTests.java
+++ b/microbenchmark-runner-core/src/test/java/jmh/mbr/core/writer/CsvResultsWriterFactoryTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jmh.mbr.core.writer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.results.AverageTimeResult;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.ResultRole;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.WorkloadParams;
+import org.openjdk.jmh.runner.format.OutputFormat;
+import org.openjdk.jmh.runner.format.OutputFormatFactory;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ */
+public class CsvResultsWriterFactoryTests {
+
+	private static String TARGET_FILE = "target/result.csv";
+
+	private CsvResultsWriterFactory factory = new CsvResultsWriterFactory();
+
+	@BeforeEach
+	public void init() {
+		File target = new File(TARGET_FILE);
+		if (target.exists()) {
+			assertThat(target.delete()).isTrue();
+		}
+	}
+
+	@Test
+	void validUri() {
+		assertThat(factory.forUri("csv:target/empty.csv")).isNotNull();
+	}
+
+	@Test
+	void writeEmptyResults() {
+		RunResult runResult = new RunResult(null, Collections.emptyList());
+		String result = output(runResult);
+		assertThat(new File(TARGET_FILE)).exists();
+		assertThat(result).startsWith(System.lineSeparator());
+		assertThat(result).contains("class, method, median, mean, range");
+	}
+
+	@Test
+	void writeActualResults() {
+		BenchmarkParams params = params();
+		Collection<BenchmarkResult> data = Arrays.<BenchmarkResult> asList(new BenchmarkResult(null, data()));
+		RunResult runResult = new RunResult(params, data);
+		String result = output(runResult);
+		assertThat(result).containsSubsequence("class, method, median, mean, range", "Foo, exec");
+	}
+
+	@Test
+	void writeParamResult() {
+		BenchmarkParams params = params("a=b");
+		Collection<BenchmarkResult> data = Arrays.<BenchmarkResult> asList(new BenchmarkResult(null, data()));
+		RunResult runResult = new RunResult(params, data);
+		String result = output(runResult);
+		// System.err.println(result);
+		assertThat(result).containsSubsequence("class, method, a, median, mean, range", "Foo, exec, b");
+	}
+
+	@Test
+	void writeSecondaryResult() {
+		BenchmarkParams params = params("a=b");
+		Collection<BenchmarkResult> data = Arrays.<BenchmarkResult> asList(new BenchmarkResult(null, data("bar")));
+		RunResult runResult = new RunResult(params, data);
+		String result = output(runResult);
+		// System.err.println(result);
+		assertThat(result).containsSubsequence("class, method, a, bar, median, mean, range", "Foo, exec, b");
+	}
+
+	@Test
+	void writeMixedParamResults() {
+		Collection<BenchmarkResult> data = Arrays.<BenchmarkResult> asList(new BenchmarkResult(null, data()));
+		String result = output(new RunResult(params("a=b"), data), new RunResult(params("a=e", "c=d"), data));
+		// System.err.println(result);
+		assertThat(result).containsSubsequence("class, method, a, c, median, mean, range", "Foo, exec, b, ,", "e, d");
+	}
+
+	@Test
+	void writeMixedSecondaryResults() {
+		Collection<BenchmarkResult> data = Arrays.<BenchmarkResult> asList(new BenchmarkResult(null, data()));
+		Collection<BenchmarkResult> seconds = Arrays
+				.<BenchmarkResult> asList(new BenchmarkResult(null, data("bar", "spam")));
+		String result = output(new RunResult(params(), data), new RunResult(params(), seconds));
+		// System.err.println(result);
+		assertThat(result).containsSubsequence("class, method, bar, spam, median, mean, range", "Foo, exec, , ",
+				"Foo, exec, 1.000");
+	}
+
+	private BenchmarkParams params(String... workloads) {
+		WorkloadParams workload = new WorkloadParams();
+		for (int i = 0; i < workloads.length; i++) {
+			String pair = workloads[i];
+			String key = pair;
+			String value = "";
+			if (pair.contains("=")) {
+				key = pair.split("=")[0];
+				value = pair.split("=")[1].trim();
+				workload.put(key, value, i);
+			}
+		}
+		return new BenchmarkParams("com.example.Foo.exec", "bar", true, 1, new int[] { 1 }, Arrays.asList("thread"), 1, 0,
+				null, null, Mode.AverageTime, workload, TimeUnit.MILLISECONDS, 1, "", Collections.emptyList(), "1.8", "JDK",
+				"1.8", "1.21", TimeValue.NONE);
+	}
+
+	private Collection<IterationResult> data(String... seconds) {
+		IterationResult result = new IterationResult(null, null, null);
+		result.addResult(new AverageTimeResult(ResultRole.PRIMARY, "foo", 15, 300000000, TimeUnit.MILLISECONDS));
+		for (String label : seconds) {
+			result.addResult(new AverageTimeResult(ResultRole.SECONDARY, label, 1, 1000000, TimeUnit.MILLISECONDS));
+		}
+		return Arrays.asList(result);
+	}
+
+	private String output(RunResult... runResult) {
+		OutputStream stream = new ByteArrayOutputStream();
+		OutputFormat output = OutputFormatFactory.createFormatInstance(new PrintStream(stream), VerboseMode.NORMAL);
+		factory.forUri("csv:" + TARGET_FILE).write(output, Arrays.asList(runResult));
+		String result = stream.toString();
+		return result;
+	}
+
+}


### PR DESCRIPTION
Writes the output in csv format (to the console and to a file). Activated with
`-DpublishTo=csv:./path/to/file.csv`. The file will be overwritten if it 
already exists. If the file cannot be written a warning will be printed on 
the console.