### PR TITLE
Allow null uri in ResultsWriterFactory

### DIFF
--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/JmhSupport.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/JmhSupport.java
@@ -14,7 +14,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
@@ -133,7 +132,7 @@ public class JmhSupport {
 	 *
 	 * @param jmhTestClass class under benchmark.
 	 * @return the report file name such as {@code project.version_yyyy-MM-dd_ClassName.json} eg.
-	 * {@literal 1.11.0.BUILD-SNAPSHOT_2017-03-07_MappingMongoConverterBenchmark.json}
+	 *         {@literal 1.11.0.BUILD-SNAPSHOT_2017-03-07_MappingMongoConverterBenchmark.json}
 	 */
 	public String reportFilename(Class<?> jmhTestClass) {
 
@@ -253,35 +252,29 @@ public class JmhSupport {
 	}
 
 	/**
-	 * Resolve the given resource location to a {@code java.io.File}, i.e. to a file in the file system.
-	 *
-	 * @param resourceLocation the resource location.
-	 * @return {@link File} for {@code resourceLocation}.
-	 */
-	private File getFile(String resourceLocation) {
-		return new File(URI.create(resourceLocation));
-	}
-
-	/**
 	 * Publish results to an external system.
 	 *
 	 * @param results must not be {@literal null}.
 	 */
 	public void publishResults(OutputFormat output, Collection<RunResult> results) {
 
-		if (results.isEmpty() || !Environment.containsProperty("publishTo")) {
-			return;
-		}
-
 		String uris = Environment.getProperty("publishTo");
 
+		String[] split;
 		if (uris != null) {
-			for (String uri : uris.split(",")) {
-				try {
-					ResultsWriter.forUri(uri.trim()).write(output, results);
-				} catch (Exception e) {
-					System.err.println(String.format("Cannot save benchmark results to '%s'. Error was %s.", uri, e));
+			split = uris.split(",");
+		} else {
+			// If not specified we pass in null so the result writer has a chance
+			split = new String[] { "" };
+		}
+		for (String uri : split) {
+			try {
+				ResultsWriter writer = ResultsWriter.forUri(uri.trim());
+				if (writer != null) {
+					writer.write(output, results);
 				}
+			} catch (Exception e) {
+				System.err.println(String.format("Cannot save benchmark results to '%s'. Error was %s.", uri, e));
 			}
 		}
 	}

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/ResultsWriterFactory.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/ResultsWriterFactory.java
@@ -10,17 +10,18 @@
 package jmh.mbr.core;
 
 /**
- * SPI for {@link ResultsWriter} plugins. Uses an opaque {@code uri} to specify the desired target where results can be written to.
+ * SPI for {@link ResultsWriter} plugins. Uses an opaque {@code uri} to specify the desired target where results can be
+ * written to.
  *
  * @see java.util.ServiceLoader
  */
 public interface ResultsWriterFactory {
 
 	/**
-	 * Creates a new {@link ResultsWriter} for {@code uri}.
-	 * Implementations may return {@literal null} if the {@code uri} is not supported.
+	 * Creates a new {@link ResultsWriter} for {@code uri}. Implementations may return {@literal null} if the {@code uri}
+	 * is not supported.
 	 *
-	 * @param uri target location to which results are written to.
+	 * @param uri target location to which results are written to (may be null or empty).
 	 * @return the {@link ResultsWriter} implementation or {@literal null} if the {@code uri} is not supported.
 	 */
 	ResultsWriter forUri(String uri);

--- a/microbenchmark-runner-core/src/test/java/jmh/mbr/core/JmhSupportUnitTests.java
+++ b/microbenchmark-runner-core/src/test/java/jmh/mbr/core/JmhSupportUnitTests.java
@@ -9,8 +9,6 @@
  */
 package jmh.mbr.core;
 
-import static org.assertj.core.api.Assertions.*;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -23,6 +21,8 @@ import org.openjdk.jmh.results.IterationResult;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.format.OutputFormat;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Unit tests for {@link JmhSupport}.
  */
@@ -34,7 +34,7 @@ class JmhSupportUnitTests {
 		TestResultsWriterFactory.REGISTRY.put("foo", FooResultWriter::new);
 		TestResultsWriterFactory.REGISTRY.put("bar", BarResultWriter::new);
 
-		System.setProperty("publishTo", "foo,bar");
+		System.setProperty("publishTo", "foo,bar,none");
 
 		try {
 			JmhSupport support = new JmhSupport();
@@ -48,6 +48,22 @@ class JmhSupportUnitTests {
 
 		assertThat(FooResultWriter.written).isTrue();
 		assertThat(BarResultWriter.written).isTrue();
+	}
+
+	@Test
+	void shouldBeAbleToWriteToEmptyUri() {
+
+		TestResultsWriterFactory.REGISTRY.put("", FooResultWriter::new);
+
+		try {
+			JmhSupport support = new JmhSupport();
+			RunResult runResult = new RunResult(null, Collections.emptyList());
+			support.publishResults(SilentOutputFormat.INSTANCE, Collections.singleton(runResult));
+		} finally {
+			TestResultsWriterFactory.REGISTRY.remove("");
+		}
+
+		assertThat(FooResultWriter.written).isTrue();
 	}
 
 	static class FooResultWriter implements ResultsWriter {
@@ -80,7 +96,8 @@ class JmhSupportUnitTests {
 		}
 
 		@Override
-		public void iterationResult(BenchmarkParams benchParams, IterationParams params, int iteration, IterationResult data) {
+		public void iterationResult(BenchmarkParams benchParams, IterationParams params, int iteration,
+				IterationResult data) {
 
 		}
 

--- a/microbenchmark-runner-core/src/test/java/jmh/mbr/core/ResultsWriterFactoryTests.java
+++ b/microbenchmark-runner-core/src/test/java/jmh/mbr/core/ResultsWriterFactoryTests.java
@@ -21,6 +21,11 @@ class ResultsWriterFactoryTests {
 	}
 
 	@Test
+	void nouri() {
+		assertThat(ResultsWriter.forUri("")).isNull();
+	}
+
+	@Test
 	void empty() {
 		assertThat(ResultsWriter.forUri("file:./target")).isNull();
 	}


### PR DESCRIPTION
So that it is possible to implement a result writer that always
emits results (e.g. by ignoring the uri and writing to stdout)