### PR TITLE
Add ElasticsearchWriter extension.

### DIFF
--- a/microbenchmark-runner-core/pom.xml
+++ b/microbenchmark-runner-core/pom.xml
@@ -20,11 +20,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/BenchmarkConfigProperties.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/BenchmarkConfigProperties.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.core;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * @author Christoph Strobl
+ */
+public
+interface BenchmarkConfigProperties {
+
+	String PREFIX = "jmh.mbr.";
+
+	ConfigProperty<Boolean> ENABLED = new ConfigProperty<>(true, PREFIX + "enabled");
+
+	ConfigProperty<String> PROJECT = new ConfigProperty<>(null, PREFIX + "project");
+	ConfigProperty<String> VERSION = new ConfigProperty<>(null, PREFIX + "project.version");
+	ConfigProperty<String> PUBLISH_URI = new ConfigProperty<>(null, PREFIX + "report.publishTo");
+	ConfigProperty<String> BENCHMARK_REPORT_DIR = new ConfigProperty<>(null, PREFIX + "report.dir");
+
+	ConfigProperty<Integer> WARMUP_ITERATIONS = new ConfigProperty<>(-1, PREFIX + "warmup.iterations", "wi");
+	ConfigProperty<Integer> WARMUP_BATCH_SIZE = new ConfigProperty<>(-1, PREFIX + "warmup.batchSize", "wbs");
+	ConfigProperty<Duration> WARMUP_TIME = new ConfigProperty<>(Duration.ZERO, PREFIX + "warmup.time", "w");
+	ConfigProperty<String> WARMUP_MODE = new ConfigProperty<>(null, PREFIX + "warmup.mode", "wm");
+
+	ConfigProperty<Integer> MEASUREMENT_ITERATIONS = new ConfigProperty<>(-1, PREFIX + "measurement.iterations", "i");
+	ConfigProperty<Integer> MEASUREMENT_BATCH_SIZE = new ConfigProperty<>(-1, PREFIX + "measurement.batchSize", "bs");
+	ConfigProperty<Duration> MEASUREMENT_TIME = new ConfigProperty<>(Duration.ZERO, PREFIX + "measurement.time", "r");
+
+	ConfigProperty<String> MODE = new ConfigProperty<>(null, PREFIX + "mode", "bm");
+	ConfigProperty<Duration> TIMEOUT = new ConfigProperty<>(Duration.ZERO, PREFIX + "timeout", "to");
+
+	ConfigProperty<Integer> FORKS = new ConfigProperty<>(-1, PREFIX + "forks", "f");
+
+	static Iterator<ConfigProperty<?>> iterator() {
+		return Arrays.<ConfigProperty<?>>asList(ENABLED, PROJECT, VERSION, PUBLISH_URI, BENCHMARK_REPORT_DIR, WARMUP_ITERATIONS, WARMUP_BATCH_SIZE, WARMUP_TIME, WARMUP_MODE, MEASUREMENT_ITERATIONS, MEASUREMENT_TIME, MEASUREMENT_BATCH_SIZE, MODE, TIMEOUT, FORKS).iterator();
+	}
+
+	class ConfigProperty<T> {
+
+		private final String[] properties;
+		private final T defaultValue;
+
+		ConfigProperty(T defaultValue, String... properties) {
+
+			this.properties = properties;
+			this.defaultValue = defaultValue;
+		}
+
+		public String propertyName() {
+			return propertyNames()[0];
+		}
+
+		public String[] propertyNames() {
+			return properties;
+		}
+
+		public T defaultValue() {
+			return defaultValue;
+		}
+
+		Class<T> getType() {
+			return defaultValue != null ? (Class<T>) defaultValue.getClass() : (Class<T>) Object.class;
+		}
+	}
+}

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/BenchmarkConfiguration.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/BenchmarkConfiguration.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.core;
+
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author Christoph Strobl
+ */
+public interface BenchmarkConfiguration {
+
+	/**
+	 * Read {@code benchmarksEnabled} property from {@link jmh.mbr.core.Environment}.
+	 *
+	 * @return true if not set.
+	 */
+	default boolean isEnabled() {
+		return true;
+	}
+
+	/**
+	 * @return
+	 */
+	String getMode();
+
+	static BenchmarkConfiguration defaultOptions() {
+		return new EnvironmentBenchmarkConfiguration();
+	}
+
+	default String publishUri() {
+		return null;
+	}
+
+	/**
+	 * Read {@code warmupIterations} property from {@link jmh.mbr.core.Environment}.
+	 *
+	 * @return -1 if not set.
+	 */
+	int getWarmupIterations();
+
+	int getWarmupBatchSize();
+
+	String getWarmupMode();
+
+	/**
+	 * Read {@code measurementIterations} property from {@link jmh.mbr.core.Environment}.
+	 *
+	 * @return -1 if not set.
+	 */
+	int getMeasurementIterations();
+
+	int getMeasurementBatchSize();
+
+	Duration getTimeout();
+
+	/**
+	 * Read {@code forks} property from {@link jmh.mbr.core.Environment}.
+	 *
+	 * @return -1 if not set.
+	 */
+	int getForksCount();
+
+	/**
+	 * Read {@code benchmarkReportDir} property from {@link jmh.mbr.core.Environment}.
+	 *
+	 * @return {@literal null} if not set.
+	 */
+	default String getReportDirectory() {
+		return null;
+	}
+
+	/**
+	 * Read {@code measurementTime} property from {@link jmh.mbr.core.Environment}.
+	 *
+	 * @return {@link Duration#ZERO} if not set.
+	 */
+	Duration getMeasurementTime();
+
+	/**
+	 * Read {@code warmupTime} property from {@link jmh.mbr.core.Environment}.
+	 *
+	 * @return {@link Duration#ZERO} if not set.
+	 */
+	Duration getWarmupTime();
+
+	/**
+	 * Returns the report file name for {@link Class class under benchmark}.
+	 *
+	 * @param jmhTestClass class under benchmark.
+	 * @return the report file name such as {@code project.version_yyyy-MM-dd_ClassName.json} eg.
+	 * {@literal 1.11.0.BUILD-SNAPSHOT_2017-03-07_MappingMongoConverterBenchmark.json}
+	 */
+	default String reportFilename(Class<?> jmhTestClass) {
+
+		StringBuilder sb = new StringBuilder();
+		sb.append(new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
+		sb.append("_");
+		sb.append(jmhTestClass.getSimpleName());
+		sb.append(".json");
+		return sb.toString();
+	}
+
+	Map<String, Object> asMap();
+
+	class EnvironmentBenchmarkConfiguration implements BenchmarkConfiguration {
+
+		@Override
+		public String getMode() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.MODE);
+		}
+
+		/**
+		 * Read {@code benchmarksEnabled} property from {@link jmh.mbr.core.Environment}.
+		 *
+		 * @return true if not set.
+		 */
+		public boolean isEnabled() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.ENABLED);
+		}
+
+		/**
+		 * Read {@code warmupIterations} property from {@link jmh.mbr.core.Environment}.
+		 *
+		 * @return -1 if not set.
+		 */
+		public int getWarmupIterations() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.WARMUP_ITERATIONS);
+		}
+
+		@Override
+		public int getWarmupBatchSize() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.WARMUP_BATCH_SIZE);
+		}
+
+		@Override
+		public String getWarmupMode() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.WARMUP_MODE);
+		}
+
+		/**
+		 * Read {@code measurementIterations} property from {@link jmh.mbr.core.Environment}.
+		 *
+		 * @return -1 if not set.
+		 */
+		public int getMeasurementIterations() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.MEASUREMENT_ITERATIONS);
+		}
+
+		@Override
+		public int getMeasurementBatchSize() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.MEASUREMENT_ITERATIONS);
+		}
+
+		@Override
+		public Duration getTimeout() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.TIMEOUT);
+		}
+
+		/**
+		 * Read {@code forks} property from {@link jmh.mbr.core.Environment}.
+		 *
+		 * @return -1 if not set.
+		 */
+		public int getForksCount() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.FORKS);
+		}
+
+		/**
+		 * Read {@code benchmarkReportDir} property from {@link jmh.mbr.core.Environment}.
+		 *
+		 * @return {@literal null} if not set.
+		 */
+		public String getReportDirectory() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.BENCHMARK_REPORT_DIR);
+		}
+
+		/**
+		 * Read {@code measurementTime} property from {@link jmh.mbr.core.Environment}.
+		 *
+		 * @return {@link Duration#ZERO} if not set.
+		 */
+		public Duration getMeasurementTime() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.MEASUREMENT_TIME);
+		}
+
+		/**
+		 * Read {@code warmupTime} property from {@link jmh.mbr.core.Environment}.
+		 *
+		 * @return {@link Duration#ZERO} if not set.
+		 */
+		public Duration getWarmupTime() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.WARMUP_TIME);
+		}
+
+		@Override
+		public String publishUri() {
+			return Environment.getPropertyOrDefault(BenchmarkConfigProperties.PUBLISH_URI);
+		}
+
+		@Override
+		public Map<String, Object> asMap() {
+
+			return Environment.jmhConfigProperties().entrySet()
+					.stream()
+					.collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue()));
+		}
+
+		/**
+		 * Returns the report file name for {@link Class class under benchmark}.
+		 *
+		 * @param jmhTestClass class under benchmark.
+		 * @return the report file name such as {@code project.version_yyyy-MM-dd_ClassName.json} eg.
+		 * {@literal 1.11.0.BUILD-SNAPSHOT_2017-03-07_MappingMongoConverterBenchmark.json}
+		 */
+		public String reportFilename(Class<?> jmhTestClass) {
+
+			StringBuilder sb = new StringBuilder();
+
+			if (Environment.containsProperty("project.version")) {
+
+				sb.append(Environment.getProperty("project.version"));
+				sb.append("_");
+			}
+
+			sb.append(new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
+			sb.append("_");
+			sb.append(jmhTestClass.getSimpleName());
+			sb.append(".json");
+			return sb.toString();
+		}
+	}
+}

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/ResultsWriter.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/ResultsWriter.java
@@ -11,13 +11,14 @@ package jmh.mbr.core;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
 
-import lombok.SneakyThrows;
+import jmh.mbr.core.model.BenchmarkResults;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.results.format.ResultFormatFactory;
 import org.openjdk.jmh.results.format.ResultFormatType;
@@ -36,23 +37,8 @@ public interface ResultsWriter {
 	 * @param output original {@link OutputFormat} to append further details or failures that occurred while writing results.
 	 * @param results can be {@literal null}.
 	 */
-	void write(OutputFormat output, Collection<RunResult> results);
+	void write(OutputFormat output, BenchmarkResults results);
 
-	/**
-	 * Convert {@link RunResult}s to JMH Json representation.
-	 *
-	 * @param results
-	 * @return json string representation of results.
-	 * @see org.openjdk.jmh.results.format.JSONResultFormat
-	 */
-	@SneakyThrows
-	static String jsonifyResults(Collection<RunResult> results) {
-
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		ResultFormatFactory.getInstance(ResultFormatType.JSON, new PrintStream(baos, true, "UTF-8")).writeOut(results);
-
-		return new String(baos.toByteArray(), StandardCharsets.UTF_8);
-	}
 
 	/**
 	 * Creates a {@link ResultsWriter} given a {@code uri}. This method considers {@link ResultsWriter} plugins provided by {@link ResultsWriterFactory} via Java's {@link ServiceLoader} mechanism. Returns {@literal null} if no applicable {@link ResultsWriter} was found.
@@ -88,7 +74,7 @@ class CompositeResultsWriter implements ResultsWriter {
 	}
 
 	@Override
-	public void write(OutputFormat output, Collection<RunResult> results) {
+	public void write(OutputFormat output, BenchmarkResults results) {
 		for (ResultsWriter writer : writers) {
 			writer.write(output, results);
 		}

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/BenchmarkFixture.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/BenchmarkFixture.java
@@ -9,7 +9,6 @@
  */
 package jmh.mbr.core.model;
 
-import lombok.EqualsAndHashCode;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -18,7 +17,6 @@ import java.util.Map;
 /**
  * Represents a parametrized fixture.
  */
-@EqualsAndHashCode
 public class BenchmarkFixture implements BenchmarkDescriptor {
 
 	private final Map<String, Object> fixture;
@@ -75,5 +73,20 @@ public class BenchmarkFixture implements BenchmarkDescriptor {
 		sb.append(getClass().getSimpleName());
 		sb.append(fixture);
 		return sb.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		BenchmarkFixture that = (BenchmarkFixture) o;
+
+		return fixture != null ? fixture.equals(that.fixture) : that.fixture == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return fixture != null ? fixture.hashCode() : 0;
 	}
 }

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/BenchmarkParameters.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/BenchmarkParameters.java
@@ -9,9 +9,6 @@
  */
 package jmh.mbr.core.model;
 
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -40,16 +37,25 @@ class BenchmarkParameters {
 		return argumentMap.values();
 	}
 
-	@Data
-	@RequiredArgsConstructor
 	static class BenchmarkArgument {
 
 		final String name;
 		final Set<String> parameters = new LinkedHashSet<>();
 
+		public BenchmarkArgument(String name) {
+			this.name = name;
+		}
+
 		int getParameterCount() {
 			return parameters.size();
 		}
-	}
 
+		Set<String> getParameters() {
+			return parameters;
+		}
+
+		String getName() {
+			return name;
+		}
+	}
 }

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/BenchmarkResults.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/BenchmarkResults.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.core.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jmh.mbr.core.Environment;
+import jmh.mbr.core.model.BenchmarkResults.BenchmarkResult;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+
+/**
+ * @author Christoph Strobl
+ */
+public class BenchmarkResults implements Iterable<BenchmarkResult> {
+
+	private final List<RunResult> runResults;
+	private final MetaData metaData;
+
+	public BenchmarkResults(MetaData metaData, Collection<RunResult> runResults) {
+
+		this.runResults = new ArrayList<>(runResults);
+		this.metaData = metaData;
+	}
+
+	public <T> List<T> flatMapMany(Function<BenchmarkResult, T> function) {
+		return runResults.stream().map(it -> function.apply(new BenchmarkResult(metaData, it))).collect(Collectors.toList());
+	}
+
+	public MetaData getMetaData() {
+		return metaData;
+	}
+
+	/**
+	 * @return the raw {@link RunResult jmh results}.
+	 */
+	public List<RunResult> getRawResults() {
+		return runResults;
+	}
+
+	@Override
+	public Iterator<BenchmarkResult> iterator() {
+		return runResults.stream().map(it -> new BenchmarkResult(metaData, it)).iterator();
+	}
+
+	/**
+	 *
+	 */
+	public static class BenchmarkResult {
+
+		private final MetaData metaData;
+		private final RunResult runResult;
+
+		public BenchmarkResult(MetaData metaData, RunResult runResult) {
+
+			this.metaData = metaData;
+			this.runResult = runResult;
+		}
+
+		public <T> T map(BiFunction<MetaData, RunResult, T> function) {
+			return function.apply(metaData, runResult);
+		}
+
+		public MetaData getMetaData() {
+			return metaData;
+		}
+
+		public Collection<org.openjdk.jmh.results.BenchmarkResult> getBenchmarkResults() {
+			return runResult.getBenchmarkResults();
+		}
+
+		public Result getPrimaryResult() {
+			return runResult.getPrimaryResult();
+		}
+
+		public Map<String, Result> getSecondaryResults() {
+			return runResult.getSecondaryResults();
+		}
+
+		public org.openjdk.jmh.results.BenchmarkResult getAggregatedResult() {
+			return runResult.getAggregatedResult();
+		}
+
+		public BenchmarkParams getParams() {
+			return runResult.getParams();
+		}
+	}
+
+	public static class MetaData {
+
+		private String project;
+		private String version;
+		private final Instant time;
+		private String os;
+		private Map<String, Object> additionalParameters = new LinkedHashMap<>();
+
+		private MetaData() {
+			time = Instant.now();
+		}
+
+		public MetaData(String project, String version) {
+
+			this();
+			this.project = project;
+			this.version = version;
+		}
+
+		public static MetaData none() {
+			return new MetaData();
+		}
+
+		public String getProject() {
+			return project;
+		}
+
+		public String getVersion() {
+			return version;
+		}
+
+		public Instant getTime() {
+			return time;
+		}
+
+		public String getOs() {
+			return os != null ? os : Environment.getOsName();
+		}
+
+		public Map<String, Object> getAdditionalParameters() {
+			return additionalParameters;
+		}
+
+		public boolean hasAdditionalMetadata() {
+			return !additionalParameters.isEmpty();
+		}
+
+		public static MetaData from(Map<String, Object> metadata) {
+
+			MetaData target = new MetaData();
+
+			for (Entry<String, Object> entry : metadata.entrySet()) {
+
+				switch (entry.getKey()) {
+					case "os":
+						target.os = entry.getValue().toString();
+						continue;
+					case "jmh.mbr.project":
+						target.project = entry.getValue().toString();
+						continue;
+					case "jmh.mbr.project.version":
+						target.version = entry.getValue().toString();
+						continue;
+					default:
+						target.additionalParameters.put(entry.getKey(), entry.getValue());
+				}
+			}
+
+			return target;
+		}
+
+		@Override
+		public String toString() {
+			return "MetaData{" +
+					"project='" + project + '\'' +
+					", version='" + version + '\'' +
+					", time=" + time +
+					", os='" + os + '\'' +
+					", additionalParameters=" + additionalParameters +
+					'}';
+		}
+	}
+}

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/ParametrizedBenchmarkMethod.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/ParametrizedBenchmarkMethod.java
@@ -9,15 +9,12 @@
  */
 package jmh.mbr.core.model;
 
-import lombok.EqualsAndHashCode;
-
 import java.lang.reflect.Method;
 import java.util.List;
 
 /**
  * Represents a parametrized benchmark method along with the actual {@link BenchmarkFixture fixtures}.
  */
-@EqualsAndHashCode(callSuper = true)
 public class ParametrizedBenchmarkMethod extends HierarchicalBenchmarkDescriptor implements MethodAware {
 
 	ParametrizedBenchmarkMethod(BenchmarkMethod descriptor, List<BenchmarkFixture> children) {
@@ -42,5 +39,15 @@ public class ParametrizedBenchmarkMethod extends HierarchicalBenchmarkDescriptor
 	@Override
 	public boolean isUnderlyingMethod(Method method) {
 		return getDescriptor().isUnderlyingMethod(method);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return super.equals(obj);
 	}
 }

--- a/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/StateClass.java
+++ b/microbenchmark-runner-core/src/main/java/jmh/mbr/core/model/StateClass.java
@@ -9,8 +9,6 @@
  */
 package jmh.mbr.core.model;
 
-import lombok.RequiredArgsConstructor;
-
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,10 +23,13 @@ import org.openjdk.jmh.annotations.State;
 /**
  * Value object to encapsulate a JMH {@code @State} class.
  */
-@RequiredArgsConstructor
 class StateClass {
 
 	private final Class<?> stateClass;
+
+	public StateClass(Class<?> stateClass) {
+		this.stateClass = stateClass;
+	}
 
 	/**
 	 * Create a {@link StateClass} given {@link Class}.
@@ -70,7 +71,7 @@ class StateClass {
 
 		if (annotation != null
 				&& (annotation.value().length == 0
-						|| (annotation.value().length == 1 && annotation.value()[0].equals(Param.BLANK_ARGS)))
+				|| (annotation.value().length == 1 && annotation.value()[0].equals(Param.BLANK_ARGS)))
 				&& field.getType().isEnum()) {
 			return Arrays.asList(field.getType().getEnumConstants()).stream().map(Object::toString)
 					.collect(Collectors.toList());

--- a/microbenchmark-runner-core/src/test/java/jmh/mbr/core/JmhSupportUnitTests.java
+++ b/microbenchmark-runner-core/src/test/java/jmh/mbr/core/JmhSupportUnitTests.java
@@ -9,10 +9,14 @@
  */
 package jmh.mbr.core;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.core.model.BenchmarkResults.MetaData;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.IterationParams;
@@ -20,8 +24,6 @@ import org.openjdk.jmh.results.BenchmarkResult;
 import org.openjdk.jmh.results.IterationResult;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.format.OutputFormat;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link JmhSupport}.
@@ -34,14 +36,14 @@ class JmhSupportUnitTests {
 		TestResultsWriterFactory.REGISTRY.put("foo", FooResultWriter::new);
 		TestResultsWriterFactory.REGISTRY.put("bar", BarResultWriter::new);
 
-		System.setProperty("publishTo", "foo,bar,none");
+		System.setProperty("jmh.mbr.report.publishTo", "foo,bar,none");
 
 		try {
-			JmhSupport support = new JmhSupport();
+			JmhSupport support = new JmhSupport(BenchmarkConfiguration.defaultOptions());
 			RunResult runResult = new RunResult(null, Collections.emptyList());
-			support.publishResults(SilentOutputFormat.INSTANCE, Collections.singleton(runResult));
+			support.publishResults(SilentOutputFormat.INSTANCE, new BenchmarkResults(MetaData.none(), Collections.singleton(runResult)));
 		} finally {
-			System.clearProperty("publishTo");
+			System.clearProperty("jmh.mbr.report.publishTo");
 			TestResultsWriterFactory.REGISTRY.remove("foo");
 			TestResultsWriterFactory.REGISTRY.remove("bar");
 		}
@@ -56,9 +58,9 @@ class JmhSupportUnitTests {
 		TestResultsWriterFactory.REGISTRY.put("", FooResultWriter::new);
 
 		try {
-			JmhSupport support = new JmhSupport();
+			JmhSupport support = new JmhSupport(BenchmarkConfiguration.defaultOptions());
 			RunResult runResult = new RunResult(null, Collections.emptyList());
-			support.publishResults(SilentOutputFormat.INSTANCE, Collections.singleton(runResult));
+			support.publishResults(SilentOutputFormat.INSTANCE, new BenchmarkResults(MetaData.none(), Collections.singleton(runResult)));
 		} finally {
 			TestResultsWriterFactory.REGISTRY.remove("");
 		}
@@ -71,7 +73,7 @@ class JmhSupportUnitTests {
 		static boolean written = false;
 
 		@Override
-		public void write(OutputFormat output, Collection<RunResult> results) {
+		public void write(OutputFormat output, BenchmarkResults results) {
 			written = true;
 		}
 	}
@@ -81,7 +83,7 @@ class JmhSupportUnitTests {
 		static boolean written = false;
 
 		@Override
-		public void write(OutputFormat output, Collection<RunResult> results) {
+		public void write(OutputFormat output, BenchmarkResults results) {
 			written = true;
 		}
 	}

--- a/microbenchmark-runner-core/src/test/java/jmh/mbr/core/TestResultsWriterFactory.java
+++ b/microbenchmark-runner-core/src/test/java/jmh/mbr/core/TestResultsWriterFactory.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import jmh.mbr.core.model.BenchmarkResults;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.format.OutputFormat;
 
@@ -33,7 +34,7 @@ public class TestResultsWriterFactory implements ResultsWriterFactory {
 	static class TestResultsWriter implements ResultsWriter {
 
 		@Override
-		public void write(OutputFormat output, Collection<RunResult> results) {
+		public void write(OutputFormat output, BenchmarkResults results) {
 		}
 	}
 }

--- a/microbenchmark-runner-extras/pom.xml
+++ b/microbenchmark-runner-extras/pom.xml
@@ -27,6 +27,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>elasticsearch-rest-high-level-client</artifactId>
+			<version>7.5.0</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
@@ -41,6 +48,13 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>3.1.0</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/CsvResultsWriter.java
+++ b/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/CsvResultsWriter.java
@@ -14,11 +14,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Collection;
 import java.util.Collections;
 
 import jmh.mbr.core.ResultsWriter;
-import org.openjdk.jmh.results.RunResult;
+import jmh.mbr.core.model.BenchmarkResults;
 import org.openjdk.jmh.runner.format.OutputFormat;
 import org.openjdk.jmh.util.FileUtils;
 
@@ -31,12 +30,12 @@ class CsvResultsWriter implements ResultsWriter {
 	}
 
 	@Override
-	public void write(OutputFormat output, Collection<RunResult> results) {
+	public void write(OutputFormat output, BenchmarkResults results) {
 
 		String report;
 
 		try {
-			report = CsvResultsFormatter.createReport(results);
+			report = CsvResultsFormatter.createReport(results.getRawResults());
 		}
 		catch (Exception e) {
 			output.println("Report creation failed: " + captureStackTrace(e));

--- a/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/CsvResultsWriterFactory.java
+++ b/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/CsvResultsWriterFactory.java
@@ -14,7 +14,7 @@ import jmh.mbr.core.ResultsWriterFactory;
 
 /**
  * A {@link ResultsWriterFactory} that writes the output in csv format (to the console and to a file). Activated with
- * <code>-DpublishTo=csv:./path/to/file.csv</code>. The file will be overwritten if it already exists. If the file
+ * <code>-Djmh.mbr.report.publishTo=csv:./path/to/file.csv</code>. The file will be overwritten if it already exists. If the file
  * cannot be written a warning will be printed on the console.
  */
 public class CsvResultsWriterFactory implements ResultsWriterFactory {

--- a/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/ElasticsearchResultsWriter.java
+++ b/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/ElasticsearchResultsWriter.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.extras.writer;
+
+import java.io.IOException;
+
+import jmh.mbr.core.ResultsWriter;
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.core.model.BenchmarkResults.BenchmarkResult;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.openjdk.jmh.runner.format.OutputFormat;
+
+public class ElasticsearchResultsWriter implements ResultsWriter {
+
+	private final RestHighLevelClient client;
+
+	public ElasticsearchResultsWriter(String uri) {
+		this(createClient(ConnectionString.fromUri(uri)));
+	}
+
+	ElasticsearchResultsWriter(RestHighLevelClient client) {
+		this.client = client;
+	}
+
+	@Override
+	public void write(OutputFormat output, BenchmarkResults results) {
+		results.forEach(this::formatAndPublish);
+	}
+
+	private void formatAndPublish(BenchmarkResult result) {
+		publishJson(result.getMetaData().getProject(), result.map(JsonResultsFormatter::format));
+	}
+
+	void publishJson(String index, String json) {
+
+		IndexRequest request = new IndexRequest(index);
+		request.source(json, XContentType.JSON);
+
+		try {
+			client.index(request, RequestOptions.DEFAULT);
+		} catch (IOException e) {
+			System.err.print(e);
+		}
+	}
+
+	static RestHighLevelClient createClient(ConnectionString connectionString) {
+
+		RestClientBuilder builder = RestClient.builder(connectionString.getHttpHost());
+
+		// TODO: set auth header
+
+		return new RestHighLevelClient(builder);
+	}
+
+	/**
+	 * elasticsearch://[username]:[password]@[host]:[port]/
+	 *
+	 * @author Christoph Strobl
+	 */
+	static class ConnectionString {
+
+		final String host;
+		final int port;
+		final String username;
+		final char[] password;
+		final boolean ssl;
+
+		ConnectionString(String host, int port, String username, char[] password, boolean ssl) {
+
+			this.host = host;
+			this.port = port;
+			this.username = username;
+			this.password = password;
+			this.ssl = ssl;
+		}
+
+		static ConnectionString fromUri(String uri) {
+
+			boolean ssl = ssl(uri);
+
+			if (!uri.contains("://")) {
+				return new ConnectionString("localhost", 9200, null, null, ssl);
+			}
+
+			String pruned = uri.substring(uri.indexOf("://") + 3);
+
+			UserPassword upw = UserPassword.from(pruned);
+			HostPort hostPort = HostPort.from(pruned);
+
+			return new ConnectionString(hostPort.host, hostPort.port, upw.username, upw.password, ssl);
+		}
+
+		private static boolean ssl(String uri) {
+			return uri.startsWith("elasticsearchs");
+		}
+
+		HttpHost getHttpHost() {
+			return new HttpHost(this.host, this.port, ssl ? "https" : "http");
+		}
+
+
+		boolean hasCredentials() {
+			return false;
+		}
+
+		private static class UserPassword {
+
+			final String username;
+			final char[] password;
+
+			public UserPassword(String username, char[] password) {
+				this.username = username;
+				this.password = password;
+			}
+
+			static UserPassword none() {
+				return new UserPassword(null, null);
+			}
+
+			static UserPassword from(String connectionString) {
+
+				if (!connectionString.contains("@")) {
+					return none();
+				}
+
+				String[] args = connectionString.split("@");
+
+				if (!args[0].contains(":")) {
+					none();
+				}
+
+				String[] userPwd = args[0].split(":");
+				return new UserPassword(userPwd[0], userPwd[1].toCharArray());
+			}
+		}
+
+		private static class HostPort {
+
+
+			final String host;
+			final int port;
+
+			public HostPort(String host, int port) {
+				this.host = host;
+				this.port = port;
+			}
+
+			static HostPort local() {
+				return new HostPort("localhost", 9200);
+			}
+
+			static HostPort from(String connectionString) {
+
+				String part = connectionString;
+
+				if (connectionString.contains("@")) {
+					String[] args = connectionString.split("@");
+					part = args[1];
+				}
+
+				if (!part.contains(":")) {
+					return local();
+				}
+
+				String[] hostPort = part.split(":");
+				return new HostPort(hostPort[0], Integer.parseInt(hostPort[1]));
+			}
+		}
+	}
+}

--- a/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/ElasticserachResultsWriterFactory.java
+++ b/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/ElasticserachResultsWriterFactory.java
@@ -5,26 +5,22 @@
  * made available under the terms of the Eclipse Public License v2.0 which
  * accompanies this distribution and is available at
  *
- * http://www.eclipse.org/legal/epl-v20.html
+ * https://www.eclipse.org/legal/epl-v20.html
  */
 package jmh.mbr.extras.writer;
 
 import jmh.mbr.core.ResultsWriter;
 import jmh.mbr.core.ResultsWriterFactory;
 
-/**
- * A {@link ResultsWriterFactory} that writes the output in csv format (to the console). Activated with
- * <code>-Djmh.mbr.report.publishTo=sysout</code>.
- */
-public class SysoutCsvResultsWriterFactory implements ResultsWriterFactory {
+public class ElasticserachResultsWriterFactory implements ResultsWriterFactory {
 
 	@Override
 	public ResultsWriter forUri(String uri) {
 
-		if (uri == null || uri.trim().isEmpty() || uri.equals("sysout")) {
-			return new SysoutCsvResultsWriter(uri);
+		if (uri == null || !uri.startsWith("elasticsearch")) {
+			return null;
 		}
 
-		return null;
+		return new ElasticsearchResultsWriter(uri);
 	}
 }

--- a/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/JsonResultsFormatter.java
+++ b/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/JsonResultsFormatter.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.extras.writer;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jmh.mbr.core.StringUtils;
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.core.model.BenchmarkResults.BenchmarkResult;
+import jmh.mbr.core.model.BenchmarkResults.MetaData;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+
+class JsonResultsFormatter {
+
+	static List<String> createReport(BenchmarkResults results) {
+		return results.flatMapMany(JsonResultsFormatter::format);
+	}
+
+	static String format(MetaData metaData, RunResult runResult) {
+		return format(new BenchmarkResult(metaData, runResult));
+	}
+
+	static String format(BenchmarkResult result) {
+
+		StringBuilder sb = new StringBuilder();
+		sb.append("{\n");
+		sb.append(formatMetadata(result.getMetaData()));
+		sb.append(formatMainData(result.getParams()));
+		sb.append(formatEnvironmentData(result.getMetaData(), result.getParams()));
+		sb.append(formatResult("primary", result.getPrimaryResult()));
+		sb.append('}');
+		return sb.toString();
+	}
+
+	static String formatMetadata(MetaData metaData) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("    \"date\" : \"" + metaData.getTime().toString() + "\",\n");
+		sb.append("    \"project\" : \"" + metaData.getProject() + "\",\n");
+		sb.append("    \"version\" : \"" + metaData.getVersion() + "\",\n");
+
+		return sb.toString();
+	}
+
+	static String formatMainData(BenchmarkParams params) {
+
+		StringBuilder sb = new StringBuilder();
+		sb.append("    \"group\" : \"" + extractClass(params.getBenchmark()) + "\",\n");
+		sb.append("    \"benchmark\" : \"" + extractBenchmarkName(params.getBenchmark()) + "\",\n");
+		sb.append("    \"method\" : \"" + params.getBenchmark() + "\",\n");
+		sb.append("    \"mode\" : \"" + params.getMode().shortLabel() + "\",\n");
+
+		return sb.toString();
+	}
+
+	static String formatEnvironmentData(MetaData metaData, BenchmarkParams params) {
+
+		StringBuilder sb = new StringBuilder();
+		sb.append("    \"env\" : {\n");
+		sb.append("        \"jvm\" : \"" + toJsonString(params.getJvm()) + "\",\n");
+		sb.append("        \"jvmArgs\" : " + toJsonArray(params.getJvmArgs()) + ",\n");
+		sb.append("        \"vmVersion\" : \"" + toJsonString(params.getVmVersion()) + "\",\n");
+		sb.append("        \"os\" : \"" + metaData.getOs() + "\"");
+
+		if(metaData.hasAdditionalMetadata()) {
+
+			for(Entry<String,Object> entry : metaData.getAdditionalParameters().entrySet()) {
+				sb.append(",\n");
+				sb.append("        \""+entry.getKey()+"\" : \"" + entry.getValue() + "\"");
+			}
+		}
+		sb.append("\n");
+		sb.append("    },\n");
+		return sb.toString();
+	}
+
+	static String formatResult(String name, Result result) {
+
+		StringBuilder sb = new StringBuilder();
+		sb.append("    \"" + name + "\" : {\n");
+		sb.append("        \"score\" : " + formatNumber(result.getScore()) + ",\n");
+		sb.append("        \"scoreError\" : " + formatNumber(result.getScoreError()) + ",\n");
+		{
+
+			List<Double> scoreConfidence = Arrays.stream(result.getScoreConfidence()).boxed().collect(Collectors.toList());
+			sb.append("        \"scoreConfidence\" : " + toJsonArray(scoreConfidence, JsonResultsFormatter::formatNumber) + ",\n");
+		}
+		sb.append("        \"scoreUnit\" : \"" + result.getScoreUnit() + "\"\n");
+
+		sb.append("    }\n"); // primaryMetric end
+		return sb.toString();
+	}
+
+
+	static String toJsonString(String s) {
+		StringBuilder sb = new StringBuilder();
+		for (char c : s.toCharArray()) {
+			if (Character.isISOControl(c)) {
+				continue;
+			}
+			switch (c) {
+				// use & as escape character to escape the tidying
+				case '&':
+					sb.append("&&");
+					break;
+				// we cannot escape to \\\\ since this would create sequences interpreted by the tidying
+				case '\\':
+					sb.append("&/");
+					break;
+				case '"':
+					sb.append("&'");
+					break;
+				// escape spacial chars for the tidying formatting below that might appear in a string
+				case ',':
+					sb.append(";");
+					break;
+				case '[':
+					sb.append("<");
+					break;
+				case ']':
+					sb.append(">");
+					break;
+				case '<':
+					sb.append("&-");
+					break;
+				case '>':
+					sb.append("&=");
+					break;
+				case ';':
+					sb.append("&:");
+					break;
+				case '{':
+					sb.append("&(");
+					break;
+				case '}':
+					sb.append("&)");
+					break;
+				default:
+					sb.append(c);
+			}
+		}
+		return sb.toString();
+	}
+
+	private static String toJsonArray(Collection<String> col) {
+		return toJsonArray(col, JsonResultsFormatter::wrap);
+	}
+
+
+	private static <T> String toJsonArray(Collection<T> col, Function<T, String> mapFunction) {
+		return "[" + StringUtils.collectionToDelimitedString(col.stream().map(mapFunction).collect(Collectors.toList()), ",") + "]";
+	}
+
+	private static String wrap(String source) {
+		return "\"" + source + "\"";
+	}
+
+	private static java.lang.String formatNumber(Number number) {
+
+		if (number == null) {
+			return "NaN";
+		}
+
+		double value = number.doubleValue();
+		if (Double.isInfinite(value)) {
+			if (value == Double.POSITIVE_INFINITY) {
+				return "+INF";
+			}
+			return "-INF";
+		}
+
+		DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.US);
+		symbols.setDecimalSeparator('.');
+		return new DecimalFormat("###.###", symbols).format(value);
+	}
+
+	private static String extractClass(String source) {
+
+		int index = source.lastIndexOf('.');
+		if (index <= 0) {
+			return source;
+		}
+
+		String tmp = source.substring(0, index);
+		return tmp.substring(tmp.lastIndexOf(".") + 1);
+	}
+
+	private static String extractBenchmarkName(String source) {
+
+		int index = source.lastIndexOf('.');
+		if (index <= 0) {
+			return source;
+		}
+		return source.substring(source.lastIndexOf(".") + 1);
+	}
+}

--- a/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/SysoutCsvResultsWriter.java
+++ b/microbenchmark-runner-extras/src/main/java/jmh/mbr/extras/writer/SysoutCsvResultsWriter.java
@@ -11,10 +11,9 @@ package jmh.mbr.extras.writer;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Collection;
 
 import jmh.mbr.core.ResultsWriter;
-import org.openjdk.jmh.results.RunResult;
+import jmh.mbr.core.model.BenchmarkResults;
 import org.openjdk.jmh.runner.format.OutputFormat;
 
 class SysoutCsvResultsWriter implements ResultsWriter {
@@ -26,14 +25,13 @@ class SysoutCsvResultsWriter implements ResultsWriter {
 	}
 
 	@Override
-	public void write(OutputFormat output, Collection<RunResult> results) {
+	public void write(OutputFormat output, BenchmarkResults results) {
 
 		try {
-			String report = CsvResultsFormatter.createReport(results);
 
+			String report = CsvResultsFormatter.createReport(results.getRawResults());
 			output.println(report);
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 
 			StringWriter trace = new StringWriter();
 			e.printStackTrace(new PrintWriter(trace));

--- a/microbenchmark-runner-extras/src/main/resources/META-INF/services/jmh.mbr.core.ResultsWriterFactory
+++ b/microbenchmark-runner-extras/src/main/resources/META-INF/services/jmh.mbr.core.ResultsWriterFactory
@@ -9,3 +9,4 @@
 #
 jmh.mbr.extras.writer.CsvResultsWriterFactory
 jmh.mbr.extras.writer.SysoutCsvResultsWriterFactory
+jmh.mbr.extras.writer.ElasticserachResultsWriterFactory

--- a/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/RunResultGenerator.java
+++ b/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/RunResultGenerator.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.extras;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Random;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.ResultRole;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.results.ThroughputResult;
+import org.openjdk.jmh.runner.IterationType;
+import org.openjdk.jmh.runner.WorkloadParams;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+
+public class RunResultGenerator {
+
+	private static final String JVM_DUMMY = "javadummy";
+
+	private static final String JDK_VERSION_DUMMY = "jdk-11.0.1.jdk";
+
+	private static final String VM_NAME_DUMMY = "DummyVM";
+
+	private static final String VM_VERSION_DUMMY = "4711";
+
+	private static final String JMH_VERSION_DUMMY = "11.0.1+13-LTS";
+
+	public static Collection<RunResult> generate(String name) {
+
+		BenchmarkParams params = params(name);
+		return generate(params, benchmarkResults(params, 3, 10, 20, 30));
+	}
+
+	public static Collection<RunResult> generate(BenchmarkParams params, Collection<BenchmarkResult> results) {
+		return Collections.singleton(new RunResult(params, results));
+	}
+
+
+	public static BenchmarkParams params(String name) {
+
+		BenchmarkParams params = new BenchmarkParams(
+				name+".log",
+				name + ".benchmark_" + Mode.Throughput,
+				false,
+				1,
+				new int[]{1},
+				Collections.<String>emptyList(),
+
+				1,
+				1,
+				new IterationParams(IterationType.WARMUP, 10, TimeValue.seconds(5), 1),
+				new IterationParams(IterationType.MEASUREMENT, 10, TimeValue.seconds(10), 1),
+				Mode.Throughput,
+				new WorkloadParams(),
+				TimeUnit.SECONDS, 1,
+				JVM_DUMMY,
+				Collections.<String>emptyList(),
+				JDK_VERSION_DUMMY, VM_NAME_DUMMY, VM_VERSION_DUMMY, JMH_VERSION_DUMMY,
+				TimeValue.days(1));
+
+		return params;
+	}
+
+	public static Collection<BenchmarkResult> benchmarkResults(BenchmarkParams params, int iterations, Integer... ops) {
+
+		Collection<BenchmarkResult> benchmarkResults = new ArrayList<>();
+		Collection<IterationResult> iterationResults = new ArrayList<>(iterations);
+
+		for (int iteration = 0; iteration < iterations; iteration++) {
+			IterationResult iterationResult = generateIterationResult(iteration, params, ops);
+			iterationResults.add(iterationResult);
+		}
+
+		benchmarkResults.add(new BenchmarkResult(params, iterationResults));
+		return benchmarkResults;
+	}
+
+	private static IterationResult generateIterationResult(int iteration, BenchmarkParams params, Integer[] ops) {
+
+		IterationResult iterationResult = new IterationResult(params, params.getMeasurement(), null);
+		for (Integer operations : ops) {
+			iterationResult.addResult(new ThroughputResult(ResultRole.PRIMARY, params.getBenchmark()+".log", operations, 1000 * 1000, TimeUnit.MILLISECONDS));
+		}
+		return iterationResult;
+	}
+
+
+	public static Collection<RunResult> random() {
+
+		Collection<RunResult> results = new TreeSet<>(RunResult.DEFAULT_SORT_COMPARATOR);
+
+		Random r = new Random(12345);
+		Random ar = new Random(12345);
+
+		for (int b = 0; b < r.nextInt(10); b++) {
+
+			WorkloadParams ps = new WorkloadParams();
+			ps.put("param0", "value0", 0);
+			ps.put("param1", "[value1]", 1);
+			ps.put("param2", "{value2}", 2);
+			ps.put("param3", "'value3'", 3);
+			ps.put("param4", "\"value4\"", 4);
+			BenchmarkParams params = new BenchmarkParams(
+					"benchmark_" + b,
+					RunResultGenerator.class.getName() + ".benchmark_" + b + "_" + Mode.Throughput,
+					false,
+					r.nextInt(1000),
+					new int[]{r.nextInt(1000)},
+					Collections.<String>emptyList(),
+
+					r.nextInt(1000),
+					r.nextInt(1000),
+					new IterationParams(IterationType.WARMUP, r.nextInt(1000), TimeValue.seconds(r.nextInt(1000)), 1),
+					new IterationParams(IterationType.MEASUREMENT, r.nextInt(1000), TimeValue.seconds(r.nextInt(1000)), 1),
+					Mode.Throughput,
+					ps,
+					TimeUnit.SECONDS, 1,
+					JVM_DUMMY,
+					Collections.<String>emptyList(),
+					JDK_VERSION_DUMMY, VM_NAME_DUMMY, VM_VERSION_DUMMY, JMH_VERSION_DUMMY,
+					TimeValue.days(1));
+
+			Collection<BenchmarkResult> benchmarkResults = new ArrayList<>();
+			for (int f = 0; f < r.nextInt(10); f++) {
+				Collection<IterationResult> iterResults = new ArrayList<>();
+				for (int c = 0; c < r.nextInt(10); c++) {
+					IterationResult res = new IterationResult(params, params.getMeasurement(), null);
+					res.addResult(new ThroughputResult(ResultRole.PRIMARY, "test", r.nextInt(1000), 1000 * 1000, TimeUnit.MILLISECONDS));
+					res.addResult(new ThroughputResult(ResultRole.SECONDARY, "secondary1", r.nextInt(1000), 1000 * 1000, TimeUnit.MILLISECONDS));
+					res.addResult(new ThroughputResult(ResultRole.SECONDARY, "secondary2", r.nextInt(1000), 1000 * 1000, TimeUnit.MILLISECONDS));
+					if (ar.nextBoolean()) {
+						res.addResult(new ThroughputResult(ResultRole.SECONDARY, "secondary3", ar.nextInt(1000), 1000 * 1000, TimeUnit.MILLISECONDS));
+					}
+					iterResults.add(res);
+				}
+				benchmarkResults.add(new BenchmarkResult(params, iterResults));
+			}
+			results.add(new RunResult(params, benchmarkResults));
+		}
+		return results;
+	}
+}

--- a/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/CsvResultsWriterFactoryTests.java
+++ b/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/CsvResultsWriterFactoryTests.java
@@ -16,6 +16,8 @@ import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collections;
 
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.core.model.BenchmarkResults.MetaData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.results.RunResult;
@@ -55,7 +57,7 @@ class CsvResultsWriterFactoryTests {
 		OutputStream stream = new ByteArrayOutputStream();
 		OutputFormat output = OutputFormatFactory
 				.createFormatInstance(new PrintStream(stream), VerboseMode.NORMAL);
-		factory.forUri("csv:" + TARGET_FILE).write(output, Arrays.asList(runResult));
+		factory.forUri("csv:" + TARGET_FILE).write(output, new BenchmarkResults(MetaData.none(), Arrays.asList(runResult)));
 		return stream.toString();
 	}
 }

--- a/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/ElasticsearchResultsWriterFactoryTests.java
+++ b/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/ElasticsearchResultsWriterFactoryTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.extras.writer;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchResultsWriterFactoryTests {
+
+	private ElasticserachResultsWriterFactory factory = new ElasticserachResultsWriterFactory();
+
+	@Test
+	void nullUri() {
+		assertThat(factory.forUri(null)).isNull();
+	}
+
+	@Test
+	void emptyUri() {
+		assertThat(factory.forUri("")).isNull();
+	}
+
+	@Test
+	void elasticsearchEnablesFactory() {
+		assertThat(factory.forUri("elasticsearch")).isNotNull();
+	}
+
+	@Test
+	void elasticsearchWithSslEnablesFactory() {
+		assertThat(factory.forUri("elasticsearchs")).isNotNull();
+	}
+}

--- a/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/ElasticsearchResultsWriterUnitTests.java
+++ b/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/ElasticsearchResultsWriterUnitTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.extras.writer;
+
+import static org.assertj.core.api.Assertions.*;
+
+import jmh.mbr.extras.writer.ElasticsearchResultsWriter.ConnectionString;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchResultsWriterUnitTests {
+
+	// todo: test all the escaping paths for usernames containing : and @ but that is furture work
+
+	@Test
+	void justHostAndPort() {
+
+		ConnectionString connectionString = ElasticsearchResultsWriter.ConnectionString.fromUri("elasticsearch://es-server:666");
+		assertThat(connectionString.host).isEqualTo("es-server");
+		assertThat(connectionString.port).isEqualTo(666);
+		assertThat(connectionString.password).isNull();
+		assertThat(connectionString.username).isNull();
+		assertThat(connectionString.ssl).isFalse();
+	}
+
+	@Test
+	void justServicename() {
+
+		ConnectionString connectionString = ElasticsearchResultsWriter.ConnectionString.fromUri("elasticsearch");
+		assertThat(connectionString.host).isEqualTo("localhost");
+		assertThat(connectionString.port).isEqualTo(9200);
+		assertThat(connectionString.password).isNull();
+		assertThat(connectionString.username).isNull();
+		assertThat(connectionString.ssl).isFalse();
+	}
+
+	@Test
+	void withSSL() {
+
+		ConnectionString connectionString = ElasticsearchResultsWriter.ConnectionString.fromUri("elasticsearchs://es-server:666");
+		assertThat(connectionString.host).isEqualTo("es-server");
+		assertThat(connectionString.port).isEqualTo(666);
+		assertThat(connectionString.password).isNull();
+		assertThat(connectionString.username).isNull();
+		assertThat(connectionString.ssl).isTrue();
+	}
+
+	@Test
+	void withUserPassword() {
+
+		ConnectionString connectionString = ElasticsearchResultsWriter.ConnectionString.fromUri("elasticsearch://es-user:es-pwd@es-host:666");
+		assertThat(connectionString.host).isEqualTo("es-host");
+		assertThat(connectionString.port).isEqualTo(666);
+		assertThat(connectionString.password).isEqualTo("es-pwd".toCharArray());
+		assertThat(connectionString.username).isEqualTo("es-user");
+		assertThat(connectionString.ssl).isFalse();
+	}
+}

--- a/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/JsonResultsFormatterUnitTests.java
+++ b/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/JsonResultsFormatterUnitTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.extras.writer;
+
+import static org.openjdk.jmh.results.format.ResultFormatType.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.core.model.BenchmarkResults.MetaData;
+import jmh.mbr.extras.RunResultGenerator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.results.format.ResultFormatFactory;
+import org.openjdk.jmh.results.format.ResultFormatType;
+
+class JsonResultsFormatterUnitTests {
+
+	@Test
+	@Disabled
+	void nativeJson() throws UnsupportedEncodingException {
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ResultFormatFactory.getInstance(ResultFormatType.JSON, new PrintStream(baos, true, "UTF-8")).writeOut(RunResultGenerator.random());
+
+		String results = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+		System.out.println("results: " + results);
+	}
+
+	@Test
+	@Disabled
+	void nativeText() throws UnsupportedEncodingException {
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ResultFormatFactory.getInstance(TEXT, new PrintStream(baos, true, "UTF-8")).writeOut(RunResultGenerator.random());
+
+		String results = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+		System.out.println("results: " + results);
+	}
+
+	@Test
+	void json() {
+
+		MetaData metaData = new MetaData("test-project", "1.0.0.SNAPSHOT");
+		BenchmarkResults results = new BenchmarkResults(metaData, RunResultGenerator.generate("UnitTest"));
+
+		List<String> json = JsonResultsFormatter.createReport(results);
+
+		json.forEach(result -> {
+
+			Assertions.assertThat(result)
+					.contains("\"project\" : \"test-project\"")
+					.contains("\"group\" : \"UnitTest\"")
+					.contains("\"benchmark\" : \"log\"");
+		});
+	}
+
+	@Test
+	void metadata() {
+
+		Map<String, Object> raw = new LinkedHashMap<>();
+		raw.put("jmh.mbr.project", "test-project");
+		raw.put("jmh.mbr.project.version", "1.0.0.SNAPSHOT");
+		raw.put("jmh.mbr.marker-1", "1-marker");
+		raw.put("jmh.mbr.marker-2", "2-marker");
+
+		MetaData metaData = MetaData.from(raw);
+		BenchmarkResults results = new BenchmarkResults(metaData, RunResultGenerator.generate("UnitTest"));
+
+		List<String> json = JsonResultsFormatter.createReport(results);
+
+		json.forEach(result -> {
+
+			Assertions.assertThat(result)
+					.contains(" \"jmh.mbr.marker-1\" : \"1-marker\",")
+					.contains("\"jmh.mbr.marker-2\" : \"2-marker\"");
+		});
+	}
+}

--- a/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/SysoutResultsWriterFactoryTests.java
+++ b/microbenchmark-runner-extras/src/test/java/jmh/mbr/extras/writer/SysoutResultsWriterFactoryTests.java
@@ -9,6 +9,8 @@
  */
 package jmh.mbr.extras.writer;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -18,6 +20,8 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import jmh.mbr.core.ResultsWriter;
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.core.model.BenchmarkResults.MetaData;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.infra.BenchmarkParams;
@@ -32,8 +36,6 @@ import org.openjdk.jmh.runner.format.OutputFormatFactory;
 import org.openjdk.jmh.runner.options.TimeValue;
 import org.openjdk.jmh.runner.options.VerboseMode;
 import org.openjdk.jmh.util.ScoreFormatter;
-
-import static org.assertj.core.api.Assertions.*;
 
 class SysoutResultsWriterFactoryTests {
 
@@ -123,7 +125,7 @@ class SysoutResultsWriterFactoryTests {
 				workload.put(key, value, i);
 			}
 		}
-		return new BenchmarkParams("com.example.Foo.exec", "bar", true, 1, new int[] {1}, Collections
+		return new BenchmarkParams("com.example.Foo.exec", "bar", true, 1, new int[]{1}, Collections
 				.singletonList("thread"), 1, 0,
 				null, null, Mode.AverageTime, workload, TimeUnit.MILLISECONDS, 1, "", Collections
 				.emptyList(), "1.8", "JDK",
@@ -143,7 +145,7 @@ class SysoutResultsWriterFactoryTests {
 		OutputStream stream = new ByteArrayOutputStream();
 		OutputFormat output = OutputFormatFactory
 				.createFormatInstance(new PrintStream(stream), VerboseMode.NORMAL);
-		factory.forUri("sysout").write(output, Arrays.asList(runResult));
+		factory.forUri("sysout").write(output, new BenchmarkResults(MetaData.none(), Arrays.asList(runResult)));
 		return stream.toString();
 	}
 }

--- a/microbenchmark-runner-junit4/src/main/java/jmh/mbr/junit4/Microbenchmark.java
+++ b/microbenchmark-runner-junit4/src/main/java/jmh/mbr/junit4/Microbenchmark.java
@@ -31,6 +31,18 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import jmh.mbr.core.Environment;
+import jmh.mbr.core.BenchmarkConfiguration;
+import jmh.mbr.core.JmhSupport;
+import jmh.mbr.core.StringUtils;
+import jmh.mbr.core.model.BenchmarkClass;
+import jmh.mbr.core.model.BenchmarkDescriptor;
+import jmh.mbr.core.model.BenchmarkDescriptorFactory;
+import jmh.mbr.core.model.BenchmarkFixture;
+import jmh.mbr.core.model.BenchmarkMethod;
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.core.model.BenchmarkResults.MetaData;
+import jmh.mbr.core.model.HierarchicalBenchmarkDescriptor;
 import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.Filterable;
@@ -58,16 +70,6 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.util.UnCloseablePrintStream;
 import org.openjdk.jmh.util.Utils;
 
-import jmh.mbr.core.Environment;
-import jmh.mbr.core.JmhSupport;
-import jmh.mbr.core.StringUtils;
-import jmh.mbr.core.model.BenchmarkClass;
-import jmh.mbr.core.model.BenchmarkDescriptor;
-import jmh.mbr.core.model.BenchmarkDescriptorFactory;
-import jmh.mbr.core.model.BenchmarkFixture;
-import jmh.mbr.core.model.BenchmarkMethod;
-import jmh.mbr.core.model.HierarchicalBenchmarkDescriptor;
-
 /**
  * JMH Microbenchmark runner that turns methods annotated with {@link Benchmark} into runnable methods allowing
  * execution through JUnit.
@@ -80,7 +82,7 @@ public class Microbenchmark extends ParentRunner<BenchmarkDescriptor> implements
 	private final Map<String, Description> fixtureMethodDescriptions = new LinkedHashMap<>();
 
 	private final Object childrenLock = new Object();
-	private final JmhSupport jmhRunner = new JmhSupport();
+	private final JmhSupport jmhRunner = new JmhSupport(BenchmarkConfiguration.defaultOptions());
 	private final BenchmarkClass benchmarkClass;
 
 	private Collection<BenchmarkDescriptor> filteredChildren;
@@ -118,7 +120,8 @@ public class Microbenchmark extends ParentRunner<BenchmarkDescriptor> implements
 	 * @param errors
 	 */
 	@Override
-	protected void collectInitializationErrors(List<Throwable> errors) {}
+	protected void collectInitializationErrors(List<Throwable> errors) {
+	}
 
 	@Override
 	protected List<BenchmarkDescriptor> getChildren() {
@@ -256,7 +259,8 @@ public class Microbenchmark extends ParentRunner<BenchmarkDescriptor> implements
 	}
 
 	@Override
-	protected void runChild(BenchmarkDescriptor child, RunNotifier notifier) {}
+	protected void runChild(BenchmarkDescriptor child, RunNotifier notifier) {
+	}
 
 	/**
 	 * Run matching {@link org.openjdk.jmh.annotations.Benchmark} methods.
@@ -273,7 +277,8 @@ public class Microbenchmark extends ParentRunner<BenchmarkDescriptor> implements
 		if (methods.isEmpty()) {
 			return new Statement() {
 				@Override
-				public void evaluate() {}
+				public void evaluate() {
+				}
 			};
 		}
 
@@ -312,7 +317,7 @@ public class Microbenchmark extends ParentRunner<BenchmarkDescriptor> implements
 		NotifyingOutputFormat notifyingOutputFormat = new NotifyingOutputFormat(notifier, cache,
 				createOutputFormat(options));
 
-		jmhRunner.publishResults(notifyingOutputFormat, new Runner(options, notifyingOutputFormat).run());
+		jmhRunner.publishResults(notifyingOutputFormat, new BenchmarkResults(MetaData.from(Environment.jmhConfigProperties()), new Runner(options, notifyingOutputFormat).run()));
 	}
 
 	/**
@@ -321,7 +326,7 @@ public class Microbenchmark extends ParentRunner<BenchmarkDescriptor> implements
 	 * The {@literal benchmark} command line argument allows overriding the defaults using {@code #} as class / method
 	 * name separator.
 	 *
-	 * @param name
+	 * @param testClass
 	 * @param methods
 	 * @return never {@literal null}.
 	 */

--- a/microbenchmark-runner-junit5-smoke-tests/pom.xml
+++ b/microbenchmark-runner-junit5-smoke-tests/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>microbenchmark-runner-parent</artifactId>
+        <groupId>com.github.mp911de.microbenchmark-runner</groupId>
+        <version>0.2.0.BUILD-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>microbenchmark-runner-junit5-smoke-tests</artifactId>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.mp911de.microbenchmark-runner</groupId>
+            <artifactId>microbenchmark-runner-junit5</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.mp911de.microbenchmark-runner</groupId>
+            <artifactId>microbenchmark-runner-extras</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>7.5.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/microbenchmark-runner-junit5-smoke-tests/src/main/resources/junit-platform.properties
+++ b/microbenchmark-runner-junit5-smoke-tests/src/main/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+jmh.mbr.project=jmh.smoke-tests
+jmh.mbr.project.version=0.2.0.SNAPSHOT
+jmh.mbr.report.publishTo=elasticsearch

--- a/microbenchmark-runner-junit5-smoke-tests/src/test/java/jmh/mbr/junit5/ResultsWriterSmokeTests.java
+++ b/microbenchmark-runner-junit5-smoke-tests/src/test/java/jmh/mbr/junit5/ResultsWriterSmokeTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.junit5;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Disabled;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Microbenchmark
+@State(Scope.Thread)
+@Disabled("Need to get system property aware test here")
+public class ResultsWriterSmokeTests {
+
+	double x1 = Math.PI;
+
+	@Benchmark
+	@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+	@Measurement(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+	public double log() {
+		return Math.log(x1);
+	}
+
+	@Benchmark
+	@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+	@Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+	public double log10() {
+		return Math.log10(x1);
+	}
+
+	@Benchmark
+	@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+	@Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+	public double log1p() {
+		return Math.log1p(x1);
+	}
+}

--- a/microbenchmark-runner-junit5/pom.xml
+++ b/microbenchmark-runner-junit5/pom.xml
@@ -21,11 +21,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-engine</artifactId>
 		</dependency>

--- a/microbenchmark-runner-junit5/src/main/java/jmh/mbr/junit5/execution/ConfigurationParameterBenchmarkConfiguration.java
+++ b/microbenchmark-runner-junit5/src/main/java/jmh/mbr/junit5/execution/ConfigurationParameterBenchmarkConfiguration.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package jmh.mbr.junit5.execution;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import jmh.mbr.core.BenchmarkConfigProperties;
+import jmh.mbr.core.BenchmarkConfigProperties.ConfigProperty;
+import jmh.mbr.core.BenchmarkConfiguration;
+import jmh.mbr.core.Environment;
+import org.junit.platform.engine.ConfigurationParameters;
+
+public class ConfigurationParameterBenchmarkConfiguration implements BenchmarkConfiguration {
+
+	private final ConfigurationParameters configurationParameters;
+
+	public ConfigurationParameterBenchmarkConfiguration(ConfigurationParameters configurationParameters) {
+		this.configurationParameters = configurationParameters;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.ENABLED, Boolean::parseBoolean);
+	}
+
+	@Override
+	public int getWarmupIterations() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.WARMUP_ITERATIONS, Integer::parseInt);
+	}
+
+	@Override
+	public Duration getWarmupTime() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.WARMUP_TIME, it -> Duration.ofSeconds(Long.parseLong(it)));
+	}
+
+	@Override
+	public Map<String, Object> asMap() {
+
+		Map<String, Object> properties = Environment.jmhConfigProperties();
+		BenchmarkConfigProperties.iterator().forEachRemaining(it -> {
+
+			Object value = getConfigParameterOrDefault((ConfigProperty<Object>) it, t -> t);
+			if (value != null) {
+				properties.put(it.propertyName(), value);
+			}
+		});
+		return properties;
+	}
+
+	@Override
+	public int getWarmupBatchSize() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.WARMUP_BATCH_SIZE, Integer::parseInt);
+	}
+
+	@Override
+	public String getWarmupMode() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.WARMUP_MODE, it -> it);
+	}
+
+	@Override
+	public int getMeasurementIterations() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.MEASUREMENT_ITERATIONS, Integer::parseInt);
+	}
+
+	@Override
+	public int getMeasurementBatchSize() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.MEASUREMENT_BATCH_SIZE, Integer::parseInt);
+	}
+
+	@Override
+	public Duration getMeasurementTime() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.MEASUREMENT_TIME, it -> Duration.ofSeconds(Long.parseLong(it)));
+	}
+
+	@Override
+	public String getMode() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.MODE, it -> it);
+	}
+
+	@Override
+	public Duration getTimeout() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.TIMEOUT, it -> Duration.ofSeconds(Long.parseLong(it)));
+	}
+
+	@Override
+	public int getForksCount() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.FORKS, Integer::parseInt);
+	}
+
+	@Override
+	public String publishUri() {
+		return getConfigParameterOrDefault(BenchmarkConfigProperties.PUBLISH_URI, it -> it);
+	}
+
+	private <T> T getConfigParameterOrDefault(ConfigProperty<T> property, Function<String, T> mapFunction) {
+
+		for (String propertyName : property.propertyNames()) {
+
+			Optional<String> configValue = configurationParameters.get(propertyName);
+			if (configValue.isPresent()) {
+				return configValue.map(mapFunction).get();
+			}
+		}
+
+		return property.defaultValue();
+	}
+}

--- a/microbenchmark-runner-junit5/src/test/java/jmh/mbr/junit5/JmhRunnerStub.java
+++ b/microbenchmark-runner-junit5/src/test/java/jmh/mbr/junit5/JmhRunnerStub.java
@@ -1,0 +1,220 @@
+package jmh.mbr.junit5;/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import jmh.mbr.core.BenchmarkConfiguration;
+import jmh.mbr.core.JmhSupport;
+import jmh.mbr.core.model.BenchmarkClass;
+import jmh.mbr.core.model.BenchmarkDescriptor;
+import jmh.mbr.core.model.BenchmarkDescriptorFactory;
+import jmh.mbr.core.model.BenchmarkMethod;
+import jmh.mbr.core.model.BenchmarkResults;
+import jmh.mbr.junit5.descriptor.BenchmarkClassDescriptor;
+import jmh.mbr.junit5.descriptor.BenchmarkMethodDescriptor;
+import jmh.mbr.junit5.execution.JmhRunner;
+import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
+import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.reporting.ReportEntry;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.format.OutputFormat;
+import org.openjdk.jmh.runner.options.Options;
+
+/**
+ * @author Christoph Strobl
+ * @since 2019/12
+ */
+public class JmhRunnerStub extends JmhRunner {
+
+	List<RunData> runData = new ArrayList<>();
+	List<Collection<RunResult>> stubResults = new ArrayList<>();
+	JmhSupportStub supportStub;
+
+	public JmhRunnerStub(ConfigurationParameters configurationParameters, MutableExtensionRegistry extensionRegistry) {
+		super(configurationParameters, extensionRegistry);
+	}
+
+	public void execute(Class<?> benchmarkClass) {
+		execute(benchmarkClass, null);
+	}
+
+	public void execute(Class<?> benchmarkClass, EngineExecutionListener listener) {
+		super.execute(createDescriptor(benchmarkClass), new ArgumentCapturingEngineExecutionListener(listener));
+	}
+
+	@Override
+	protected Collection<RunResult> runBenchmarks(Options options, OutputFormat outputFormat) throws RunnerException {
+
+		this.runData.add(new RunData(options, outputFormat));
+
+		if (stubResults.isEmpty()) {
+			return super.runBenchmarks(options, outputFormat);
+		}
+		return getNextResults();
+	}
+
+
+	public JmhRunnerStub onRunReturn(Collection<RunResult> results) {
+
+		stubResults.add(results);
+		return this;
+	}
+
+	public JmhRunnerStub onRunReturnEmptyResult() {
+		return onRunReturn(Collections.emptyList());
+	}
+
+	@Override
+	protected JmhSupport initJmhSupport(BenchmarkConfiguration parameters) {
+		supportStub = new JmhSupportStub(parameters);
+		return supportStub;
+	}
+
+	public RunData getRunData(int run) {
+		return runData.get(run);
+	}
+
+	public RunData getRunData() {
+
+		if (runData.isEmpty()) {
+			return null;
+		}
+
+		return runData.get(runData.size() - 1);
+	}
+
+	public BenchmarkConfiguration getJmhInitOptions() {
+		return supportStub != null ? supportStub.getInitOptions() : null;
+	}
+
+	public BenchmarkResults getResult() {
+		return supportStub != null ? supportStub.getBenchmarkResults() : null;
+	}
+
+	private BenchmarkClassDescriptor createDescriptor(Class<?> javaClass) {
+
+		BenchmarkClass benchmarkClass = BenchmarkDescriptorFactory.create(javaClass)
+				.createDescriptor();
+
+		BenchmarkClassDescriptor descriptor = new BenchmarkClassDescriptor(UniqueId
+				.root("root", "root"), benchmarkClass);
+
+		for (BenchmarkDescriptor child : benchmarkClass.getChildren()) {
+
+			if (child instanceof BenchmarkMethod) {
+				BenchmarkMethod method = (BenchmarkMethod) child;
+
+				descriptor.addChild(new BenchmarkMethodDescriptor(descriptor.getUniqueId()
+						.append("method", (method).getName()), method));
+			}
+		}
+
+		return descriptor;
+	}
+
+	private Collection<RunResult> getNextResults() {
+
+		int index = runData.size() - 1;
+		if (stubResults.size() >= index) {
+			return stubResults.get(index);
+		}
+		return Collections.emptyList();
+	}
+
+
+	static class RunData {
+
+		Options options;
+		OutputFormat outputFormat;
+
+		public RunData(Options options, OutputFormat outputFormat) {
+			this.options = options;
+			this.outputFormat = outputFormat;
+		}
+
+		@Override
+		public String toString() {
+			return "RunData{" +
+					"options=" + options +
+					", outputFormat=" + outputFormat +
+					'}';
+		}
+	}
+
+	static class ArgumentCapturingEngineExecutionListener implements EngineExecutionListener {
+
+		EngineExecutionListener delegate;
+
+		List<TestDescriptor> dynamic = new ArrayList<>();
+		List<TestDescriptor> skipped = new ArrayList<>();
+		List<TestDescriptor> started = new ArrayList<>();
+		List<TestDescriptor> finished = new ArrayList<>();
+		List<TestDescriptor> published = new ArrayList<>();
+
+		public ArgumentCapturingEngineExecutionListener(EngineExecutionListener delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void dynamicTestRegistered(TestDescriptor testDescriptor) {
+
+			dynamic.add(testDescriptor);
+			if (delegate != null) {
+				delegate.dynamicTestRegistered(testDescriptor);
+			}
+		}
+
+		@Override
+		public void executionSkipped(TestDescriptor testDescriptor, String reason) {
+			skipped.add(testDescriptor);
+			if (delegate != null) {
+				delegate.executionSkipped(testDescriptor, reason);
+			}
+		}
+
+		@Override
+		public void executionStarted(TestDescriptor testDescriptor) {
+			started.add(testDescriptor);
+			if (delegate != null) {
+				delegate.executionStarted(testDescriptor);
+			}
+		}
+
+		@Override
+		public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
+			finished.add(testDescriptor);
+			if (delegate != null) {
+				delegate.executionFinished(testDescriptor, testExecutionResult);
+			}
+		}
+
+		@Override
+		public void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
+			published.add(testDescriptor);
+			if (delegate != null) {
+				delegate.reportingEntryPublished(testDescriptor, entry);
+			}
+		}
+	}
+}

--- a/microbenchmark-runner-junit5/src/test/java/jmh/mbr/junit5/JmhSupportStub.java
+++ b/microbenchmark-runner-junit5/src/test/java/jmh/mbr/junit5/JmhSupportStub.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jmh.mbr.junit5;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jmh.mbr.core.BenchmarkConfiguration;
+import jmh.mbr.core.JmhSupport;
+import jmh.mbr.core.model.BenchmarkResults;
+import org.openjdk.jmh.runner.format.OutputFormat;
+
+/**
+ * @author Christoph Strobl
+ * @since 2019/12
+ */
+public class JmhSupportStub extends JmhSupport {
+
+	final List<BenchmarkResults> resultsList = new ArrayList<>();
+	final BenchmarkConfiguration initOptions;
+
+	public JmhSupportStub(BenchmarkConfiguration jmhOptions) {
+
+		super(jmhOptions);
+		this.initOptions = jmhOptions;
+	}
+
+	@Override
+	public void publishResults(OutputFormat output, BenchmarkResults results) {
+
+		this.resultsList.add(results);
+		super.publishResults(output, results);
+	}
+
+	public BenchmarkResults getBenchmarkResults() {
+
+		if (resultsList.isEmpty()) {
+			return null;
+		}
+
+		return resultsList.get(resultsList.size() - 1);
+	}
+
+	public BenchmarkConfiguration getInitOptions() {
+		return initOptions;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
 		<module>microbenchmark-runner-extras</module>
 		<module>microbenchmark-runner-junit4</module>
 		<module>microbenchmark-runner-junit5</module>
+		<module>microbenchmark-runner-junit5-smoke-tests</module>
 	</modules>
 
 	<properties>
-		<jmh.version>1.21</jmh.version>
-		<lombok.version>1.18.2</lombok.version>
+		<jmh.version>1.22</jmh.version>
 		<assertj.version>3.11.1</assertj.version>
 		<junit4.version>4.12</junit4.version>
 		<junit5.version>5.5.1</junit5.version>
@@ -85,13 +85,6 @@
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>${junit4.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.projectlombok</groupId>
-				<artifactId>lombok</artifactId>
-				<version>${lombok.version}</version>
-				<scope>provided</scope>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Along the lines introduce a BenchmarkConfiguration that allows to read properties from the JUnit environment so one is able to use the configuration files as well.

Smoke tests still need to be some flags so they can be run depending on current setup.  